### PR TITLE
Catch errors and propagate them up the middleware stack

### DIFF
--- a/src/rate-limiter.js
+++ b/src/rate-limiter.js
@@ -67,7 +67,10 @@ class RateLimiter {
             this._store.increment(key, limit, ({
                                                    current = 1,
                                                    reset = limit
-                                               } = {}) => {
+                                               } = {}, error) => {
+                if (error) {
+                    return next(error);
+                }
 
                 // Max limit reached
                 if (current > max) {
@@ -76,9 +79,14 @@ class RateLimiter {
                     return next(err);
                 }
 
-                res.header(this._headers.remaining, Math.floor(max - current));
-                res.header(this._headers.limit, max);
-                res.header(this._headers.reset, reset);
+                try {
+                    res.header(this._headers.remaining, Math.floor(max - current));
+                    res.header(this._headers.limit, max);
+                    res.header(this._headers.reset, reset);
+                } catch (err) {
+                    return next(err);
+                }
+
 
                 next();
             });

--- a/src/redis-store.js
+++ b/src/redis-store.js
@@ -11,8 +11,7 @@ class RedisStore {
 
         this._client.get(key + '_reset', (err, value) => {
             if (err) {
-                logger.error(err);
-                throw err;
+                return callback({}, err);
             }
 
             const multi = this._client.multi();
@@ -33,8 +32,7 @@ class RedisStore {
 
             multi.exec((err, replies) => {
                 if (err) {
-                    logger.error(err);
-                    throw err;
+                    return callback({}, err);
                 }
 
                 callback({


### PR DESCRIPTION
Hey—I saw your comment in another issue about how you don't really use node anymore, so I figured I'd try to make a PR for this rather than just filing an issue—to make your life easier, in hopes that it would increase the odds of getting this merged and released as a new npm package version 😄 

---

I noticed that there are certain cases where an error can occur within this middleware in ways that make it uncatchable by the parent app, and end up crashing the entire node process.

In my case, I discovered this because a teammate had put `app.use(rateLimiter.middleware)` in a place where it could sometimes cause this middleware to run _after_ a response had already been sent, resulting in `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`, which was crashing our app.

This was definitely user error on our part.  But after digging in, I realized that there was no way for our application to `catch` that error and prevent the entire app from crashing (if someone were to make a similar mistake in the future). That's because it's being thrown inside of an async callback within this middleware... which leaves no way for it to be caught outside of this middleware.

So, this PR aims to catch errors in cases where they might occur and become uncatchable by the server application itself. Namely, that could occur if errors happen either:
- inside of the `redis-store`
- when calling `res.header()` inside of `rate-limiter.js`

this should now ensure the errors are caught and passed to the `next()` callback, so they're propagated through the express middleware stack.

---

I originally made it so that the `increment` functions in each of the "store" classes would call their `callback` with the error as their **first** parameter, which is typically what you see with node callbacks. But then realized doing it that way would potentially break backward compatibility. So I made it pass the errors as a second (optional) parameter instead, as you see in this diff. I _believe_ that should make this change fully backward compatible—even in cases where people might be passing in a custom "store" object with a custom `increment` function.

---

Let me know if there's anything you'd prefer to see changed in this code!